### PR TITLE
Fixes issue 29 Coordinate display not working in firefox/iceweasel

### DIFF
--- a/client/src/js/lib/wgo/wgo.js
+++ b/client/src/js/lib/wgo/wgo.js
@@ -790,6 +790,7 @@ Board.coordinates = {
 			var coordinatesBackground = theme_variable('coordinatesBackgroundColor', board);
 
 			if (coordinatesBackground) {
+				this.save();
 				// Draw a background behind the coordinates
 				this.beginPath();
 				this.moveTo(0, 0);
@@ -810,7 +811,6 @@ Board.coordinates = {
 				this.fill();
 
 				this.clip();
-				this.save();
 
 				this.restore();
 

--- a/client/src/js/lib/wgo/wgo.js
+++ b/client/src/js/lib/wgo/wgo.js
@@ -790,7 +790,6 @@ Board.coordinates = {
 			var coordinatesBackground = theme_variable('coordinatesBackgroundColor', board);
 
 			if (coordinatesBackground) {
-				this.save();
 				// Draw a background behind the coordinates
 				this.beginPath();
 				this.moveTo(0, 0);
@@ -809,10 +808,6 @@ Board.coordinates = {
 
 				this.fillStyle = theme_variable('coordinatesBackgroundColor', board);
 				this.fill();
-
-				this.clip();
-
-				this.restore();
 
 				xright = board.getX(-1.25);
 				xleft = board.getX(board.size + 0.25);


### PR DESCRIPTION
The issue is actually with the this.clip() function. To fix this I saved off the settings before drawing the background and then restore it when done. This prevents the clip() from being presisted.

Lines 813-815 with this.save() and this.restore() immediately afterwards I think does nothing. So I decided to move it above all the background drawing to prevent the clip state from preceding to clip out all coordinates.

If this.clip() is no longer needed I will change it and resubmit the pull request.