### PR TITLE
#82 created filter and added to page title and top labels in kifu

### DIFF
--- a/client/src/js/controllers/kifu.js
+++ b/client/src/js/controllers/kifu.js
@@ -141,7 +141,7 @@ angular.module('gokibitz.controllers')
 
 	// Set the page title
 	var titleTemplate = $interpolate(
-		'{{ white.name || "Anonymous" }} {{ white.rank }} vs. {{ black.name || "Anonymous" }} {{ black.rank }} – GoKibitz'
+		'{{ white.name || "Anonymous" }} {{ white.rank | rank }} vs. {{ black.name || "Anonymous" }} {{ black.rank | rank }} – GoKibitz'
 	);
 	$scope.$watch('info', function () {
 		if ($scope.info) {

--- a/client/src/js/filters/rank.js
+++ b/client/src/js/filters/rank.js
@@ -1,0 +1,25 @@
+angular.module('gokibitz.filters')
+    .filter('rank', function () {
+	return function (input) {
+        var number = /^[0-9]+/.exec(input);
+        var qualification = /[a-zA-Z]+/.exec(input);
+
+        if(!number || !qualification){
+            return '';
+        }
+
+        var lowerQualification = qualification[0].toLowerCase();
+
+        if(lowerQualification.indexOf("k") > -1){
+            return number[0] + "k";
+        }
+        if(lowerQualification.indexOf("d") > -1){
+            return number[0] + "d";
+        }
+        if(lowerQualification.indexOf("p") > -1){
+            return number[0] + "p";
+        }
+
+        return '';
+    }
+});

--- a/server/views/partials/kifu.jade
+++ b/server/views/partials/kifu.jade
@@ -4,7 +4,7 @@
 			.white
 				.name {{ info.white.name || 'Anonymous' }}
 				= ' '
-				.rank {{ info.white.rank }}
+				.rank {{ info.white.rank | rank}}
 				.captures(
 					tooltip-placement='right'
 					tooltip='White’s captured prisoners'
@@ -13,7 +13,7 @@
 			.black
 				.name {{ info.black.name || 'Anonymous' }}
 				= ' '
-				.rank {{ info.black.rank }}
+				.rank {{ info.black.rank | rank }}
 				.captures(
 					tooltip-placement='left'
 					tooltip='Black’s captured prisoners'


### PR DESCRIPTION
A few notes:
- this will standardize rank in the single kifu page for title and the players labels on the top
- it can be easily added to the list-kifu if we want
- the filter is not exactly defensive programming... it might be useful to pull out a list of ranks from the production DB, so we have an idea of what kind of crazy stuff servers use
- one obvious example might be for the Korean gup system (I don't know if any server actually uses it)
- another thing I didn't consider is non-latin alphabet
- I thought about addressing some corner cases like "if contains 'k' and not 'd' and not 'p'" but there might be something like "Provisional 30Kyu" or "Professional Dan" that would not pass (see point 3)
- Instead of returning '', if number != null, we could return number[0] + '?'. This is for cases like "18liu" where it will become obvious that it's a 18kyu. This helps only for DDK games of course

So, yeah, it can become more complicated very quickly. 