### PR TITLE
Convert 'offset' param from query to integer

### DIFF
--- a/server/routes/comment.js
+++ b/server/routes/comment.js
@@ -76,7 +76,7 @@ router.post('/', auth.ensureAuthenticated, function (req, res) {
 
 // Get a list of comments in reverse cron
 router.get('/', function (req, res) {
-	var offset = req.query.offset || 0;
+	var offset = parseInt(req.query.offset, 10) || 0;
 	var limit = Math.min(req.query.limit, 100) || 20;
 	var user;
 	var username = req.query.username || '';

--- a/server/routes/kifu.js
+++ b/server/routes/kifu.js
@@ -15,7 +15,7 @@ var https = require('https');
 var url = require('url');
 
 router.get('/', function (req, res) {
-	var offset = req.query.offset || 0;
+	var offset = parseInt(req.query.offset, 10) || 0;
 	var limit = Math.min(req.query.limit, 100) || 20;
 	var search = req.query.search || '';
 

--- a/server/routes/notification.js
+++ b/server/routes/notification.js
@@ -21,7 +21,7 @@ function findUser(username, callback) {
 }
 
 router.get('/', auth.ensureAuthenticated, function (req, res) {
-	var offset = req.query.offset || 0;
+	var offset = parseInt(req.query.offset, 10) || 0;
 	var limit = Math.min(req.query.limit, 100) || 20;
 	var username = req.query.username;
 	var since = req.query.since || null;

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -87,7 +87,7 @@ router.put('/:username', auth.ensureAuthenticated, function (req, res) {
 
 // Get a user's kifu
 router.get('/:user/kifu', function (req, res) {
-	var offset = req.query.offset || 0;
+	var offset = parseInt(req.query.offset, 10) || 0;
 	var limit = Math.min(req.query.limit, 100) || 20;
 	var search = req.query.search || '';
 


### PR DESCRIPTION
Running gokibitz on localhost I got 500 exception when visiting url
"/api/user/:user/kifu?offset=0"

The exception:

{"message":"Error loading kifu. MongoError: Failed to parse: { find: \"kifus\", filter: { owner: ObjectId('x'), deleted: false }, sort: { uploaded: -1 }, skip: \"0\", limit: 20 }. 'skip' field must be numeric."}

The error was caused by passing offset param as string while it was expected being integer.
This fixes the problem also in other endpoints where the offset param is passed.